### PR TITLE
handle multiple build parameters correctly

### DIFF
--- a/src/commands/trigger.yml
+++ b/src/commands/trigger.yml
@@ -33,10 +33,10 @@ parameters:
 steps:
   - run:
       name: Trigger pipeline for <<parameters.slug>> on branch <<parameters.branch>>
-      command: |
+      command: |-
         <<parameters.script>> \
           --branch <<parameters.branch>> \
-          `if [ ! -z "<<parameters.build_parameters>>" ]; then echo "--build-parameters <<parameters.build_parameters>>"; fi` \
+          $(if [ ! -z "<<parameters.build-parameters>>" ]; then echo "--build-parameters $(echo "<<parameters.build-parameters>>" | sed 's/ / --build-parameters /g')"; fi) \
           --vcs <<parameters.vcs>> \
           --circleci-url <<parameters.circleci_url>> \
           --circleci-token $<<parameters.circleci_token>> \


### PR DESCRIPTION
the previous code did not work with the script which accepts multiple build-parameters in the following form:

--build-parameters toto=titi --build-parameters tutu=tata

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
<!--
Relates OR Closes #0000
-->

## Description
<!-- Short description about the change, what have you done? -->
